### PR TITLE
Allow Carbon 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "nesbot/carbon": "^1.0",
+    "nesbot/carbon": "^1.0 ^2.0",
     "ext-calendar": "*"
   },
   "autoload": {


### PR DESCRIPTION
Current composer.json doesn't allow Carbon 2.0. Carbon 2.0 however should work since https://github.com/micronax/carbon-german-holidays/commit/b375b8392dc108c26489a5a80a4f1608041a4c2e added support for Carbon 1.0. However the requirements were set wrong.