### PR TITLE
Use ::getTimestamp() instead of ::format('u')

### DIFF
--- a/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
+++ b/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
@@ -134,7 +134,7 @@ class CarbonGermanHolidays extends Carbon
     public static function getHolidays($year, $states = self::ALL_STATES)
     {
         $holidays     = array();
-        $easterSunday = self::getEasterSunday($year)->format('u');
+        $easterSunday = self::getEasterSunday($year)->getTimeStamp();
 
         if ( ! is_array($states)) {
             $states = array($states);


### PR DESCRIPTION
Hi,

the ``$easterSunday = self::getEasterSunday($year)->format('u');`` will not generate the correct timestamp. The easter related days will always be in the past (around 1970). 

https://sandbox.onlinephpfunctions.com/c/50bd0 

Could you merge the PR? I checked it with the current easter dates and otherwise the logic is correct.

Thanks!

 \-Thomas