### PR TITLE
fix implicit float to int conversion

### DIFF
--- a/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
+++ b/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
@@ -140,7 +140,7 @@ class CarbonGermanHolidays extends Carbon
             $states = array($states);
         }
 
-        $penanceDay = mktime(0, 0, 0, 11, 22 - ($year - 1 + $year / 4) % 7, $year);
+        $penanceDay = mktime(0, 0, 0, 11, 22 - ($year - 1 + ((int) ((int) ($year / 4)) % 7)), $year);
 
 
         // For all states


### PR DESCRIPTION
On PHP 8.1, the following deprecation warning is shown:
Deprecated: Implicit conversion from float 505.5 to int loses precision in /app/vendor/fgits/carbon-german-holidays/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php on line 143

This PR fixes this deprecation warning by exlicitly casting the computation results to an int.