### PR TITLE
Update CarbonGermanHolidays.php

### DIFF
--- a/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
+++ b/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
@@ -153,7 +153,7 @@ class CarbonGermanHolidays extends Carbon
         $holidays['1. Weihnachtstag']          = mktime(0, 0, 0, 12, 25, $year);
         $holidays['2. Weihnachtstag']          = mktime(0, 0, 0, 12, 26, $year);
 
-        if (in_array(self::BERLIN, $states)) {
+        if (in_array(self::BERLIN, self::MECKLENBURG_VORPOMMERN, $states)) {
             $holidays['Internationaler Frauentag'] = mktime(0, 0, 0, 3, 8, $year);
         }
 

--- a/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
+++ b/src/Fgits/CarbonGermanHolidays/CarbonGermanHolidays.php
@@ -153,10 +153,10 @@ class CarbonGermanHolidays extends Carbon
         $holidays['1. Weihnachtstag']          = mktime(0, 0, 0, 12, 25, $year);
         $holidays['2. Weihnachtstag']          = mktime(0, 0, 0, 12, 26, $year);
 
-        if (in_array(self::BERLIN, self::MECKLENBURG_VORPOMMERN, $states)) {
+        if (array_intersect([self::BERLIN, self::MECKLENBURG_VORPOMMERN], $states)) {
             $holidays['Internationaler Frauentag'] = mktime(0, 0, 0, 3, 8, $year);
         }
-
+        
         if (in_array(self::BRANDENBURG, $states)) {
             $holidays['Ostersonntag']   = $easterSunday;
             $holidays['Pfingstsonntag'] = strtotime('+49 days', $easterSunday);


### PR DESCRIPTION
Since 2023 "Internationaler Frauentag" is holiday in Mecklenburg as well -> https://www.ndr.de/nachrichten/mecklenburg-vorpommern/Frauentag-in-MV-Landtag-beschliesst-neuen-Feiertag,frauentag370.html